### PR TITLE
change: check for whitespace span using a regex

### DIFF
--- a/libexec/compile-word-break.js
+++ b/libexec/compile-word-break.js
@@ -6,6 +6,7 @@
  *
  *  - a sorted array to facilitate binary search of the Word_Break property.
  *  - a regular expression that matches characters that have Extended_Pictographic=Yes.
+ *  - a regular expression that matches whether a span is made of solely whitespace
  *
  * For internal use only. Please keep away from children.
  *
@@ -83,6 +84,16 @@ if (es6Regexp.length < compatibleRegexp.length) {
   console.warn(`Using compatibility regexp [${compatibleRegexp.length} chars]`);
 }
 
+////////////////////////////// Whitespace regex //////////////////////////////
+let whitespaceRanges = ranges.filter(
+  ({ property }) =>
+    property === "CR" ||
+    property === "LF" ||
+    property === "Newline" ||
+    property === "WSegSpace"
+);
+let whitespaceRegExp = createRegExp(whitespaceRanges);
+
 //////////////////////// Creating the generated file /////////////////////////
 
 // Save the output in the gen/ directory.
@@ -102,6 +113,7 @@ ${ /* Create enum values for each word break property */
 };
 
 export const extendedPictographic = ${extendedPictographicRegExp};
+export const IS_WHITE_SPACE = ${whitespaceRegExp};
 
 /**
  * Constants for indexing values in WORD_BREAK_PROPERTY.
@@ -205,6 +217,18 @@ function utf16AlternativesStrategy() {
 
   let alternatives = codePoints.map(codePointToUTF16Escape);
   return `/^(?:${alternatives.join('|')})/`;
+}
+
+function createRegExp(ranges) {
+  let regexp = "";
+  for (let {start, end} of ranges) {
+    if (start === end) {
+      regexp += toUnicodeEscape(start);
+    } else {
+      regexp += toUnicodeEscape(start) + "-" + toUnicodeEscape(end);
+    }
+  }
+  return `/^[${regexp}]+$/`;
 }
 
 function codePointToUTF16Escape(codePoint) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,8 @@
 
 // See: https://unicode.org/reports/tr29/#Default_Word_Boundaries
 
-import { findBoundaries, property } from "./findBoundaries";
-import { WordBreakProperty } from "./gen/WordBreakProperty";
+import { findBoundaries } from "./findBoundaries";
+import { IS_WHITE_SPACE } from "./gen/WordBreakProperty";
 
 export { findBoundaries };
 
@@ -116,13 +116,5 @@ class LazySpan implements BasicSpan {
  * @param chunk a chunk of text. Starts and ends at word boundaries.
  */
 function isNonSpace(chunk: string): boolean {
-  return !Array.from(chunk)
-    .map(property)
-    .every(
-      (wb) =>
-        wb === WordBreakProperty.CR ||
-        wb === WordBreakProperty.LF ||
-        wb === WordBreakProperty.Newline ||
-        wb === WordBreakProperty.WSegSpace
-    );
+  return !IS_WHITE_SPACE.test(chunk);
 }


### PR DESCRIPTION
This improves the performance of `split()` by replacing the old code with a regex, created at compile time.

```
> unicode-default-word-boundary@15.1.1 benchmarks
> node benches

#split() [original] x 5.35 ops/sec ±0.62% (18 runs sampled)
#split() [optimized] x 9.26 ops/sec ±1.10% (28 runs sampled)
Fastest: #split() [optimized] (1.73x speed-up)
```

*1.73x* speed-up is nice!